### PR TITLE
Fix .cfg for mapmodels with broken textures

### DIFF
--- a/packages/models/mapmodels/mapmodels/nieb/ladder45/obj.cfg
+++ b/packages/models/mapmodels/mapmodels/nieb/ladder45/obj.cfg
@@ -1,6 +1,7 @@
-objload model.obj
-objskin    * ../../../../lunaran/panel64_2_d.jpg      panel64_2_s.jpg
-objbumpmap * ../../../../lunaran/panel64_2_local.jpg
+objload "model.obj"
+objdir "../texture/lunaran"
+objskin * "<nocompress>panel64_2_d.jpg" "<nocompress>panel64_2_s.jpg"
+objbumpmap * "<nocompress>panel64_2_local.jpg"
 
 mdlscale 400
 mdlspec 100

--- a/packages/models/mapmodels/mapmodels/nieb/tree_dead/obj.cfg
+++ b/packages/models/mapmodels/mapmodels/nieb/tree_dead/obj.cfg
@@ -1,10 +1,11 @@
-objload model.obj
+objload "model.obj"
 
-objskin bark ../../../../textures/nieb/autumn/bark01.jpg
-objskin leaf leaf01.png
+objskin "leaf" "leaf01.png"
+objdir "../texture/textures/nieb"
+objskin "bark" "autumn/bark01.jpg"
 
-objnoclip leaf 1
-objcullface leaf 0
+objnoclip "leaf" 1
+objcullface "leaf" 0
 
 mdlscale 100
 mdlcollide 1

--- a/packages/models/mapmodels/mapmodels/nieb/tree_dead_nocollide/obj.cfg
+++ b/packages/models/mapmodels/mapmodels/nieb/tree_dead_nocollide/obj.cfg
@@ -1,10 +1,12 @@
-objload ../../nieb/tree_dead/model.obj
+objdir "mapmodels/mapmodels/nieb/tree_dead"
+objload "model.obj"
 
-objskin bark ../../../../textures/nieb/autumn/bark01.jpg
-objskin leaf ../../nieb/tree_dead/leaf01.png
+objskin "leaf" "leaf01.png"
+objdir "../texture/textures/nieb"
+objskin "bark" "autumn/bark01.jpg"
 
-objnoclip leaf 1
-objcullface leaf 0
+objnoclip "leaf" 1
+objcullface "leaf" 0
 
 mdlscale 100
 mdlcollide 0
@@ -13,5 +15,5 @@ mdlspec -1
 mdlshadow 1
 mdlalphatest 0.5
 mdlalphablend 0
-mdlellipsecollide 1
+mdlellipsecollide 0
 mdlbb 3

--- a/packages/models/mapmodels/objects/millblade/md3.cfg
+++ b/packages/models/mapmodels/objects/millblade/md3.cfg
@@ -1,8 +1,9 @@
 md3load tris.md3
-md3skin 1 "../../../dg/mad065.jpg"
-md3skin 2 "../../../dg/floor_pavement_stone_four2.jpg"
+md3dir "../texture/dg"
+md3skin 1 "<>mad065.jpg"
+md3skin 2 "<>floor_pavement_stone_four2.jpg"
 md3anim mapmodel 0 23 1
-mdlambient 50
+
 mdlcollide 0
-mdlspec -1
-mdlshadow 0
+mdlspec 0
+mdlshadow 1


### PR DESCRIPTION
modifies the .cfg files for `nieb/ladder45`, `nieb/tree_dead`, `nieb/tree_dead_nocollide` and `objects/millblade` to point to the expected textures (although the overall packages organization still needs some restructuring :) )