### PR TITLE
Fix playermodel pitch when looking up/down

### DIFF
--- a/packages/models/captaincannon/blue/md5.cfg
+++ b/packages/models/captaincannon/blue/md5.cfg
@@ -9,4 +9,4 @@ md5bumpmap body "<dds>cc_body_normals.png"
 exec "packages/models/captaincannon/anims.cfg"
 mdlscale 1225
 mdlspec 60
-
+mdlyaw 90

--- a/packages/models/captaincannon/md5.cfg
+++ b/packages/models/captaincannon/md5.cfg
@@ -8,4 +8,4 @@ md5bumpmap body "<dds>cc_body_normals.png"
 exec "packages/models/captaincannon/anims.cfg"
 mdlscale 1225
 mdlspec 60
-
+mdlyaw 90

--- a/packages/models/captaincannon/red/md5.cfg
+++ b/packages/models/captaincannon/red/md5.cfg
@@ -9,4 +9,4 @@ md5bumpmap body "<dds>cc_body_normals.png"
 exec "packages/models/captaincannon/anims.cfg"
 mdlscale 1225
 mdlspec 60
-
+mdlyaw 90

--- a/packages/models/inky/blue/md5.cfg
+++ b/packages/models/inky/blue/md5.cfg
@@ -16,4 +16,4 @@ mdlglow 200
 mdlspec 30
 mdltrans 0.5 0 0 
 mdlscale 1900
-
+mdlyaw 90

--- a/packages/models/inky/md5.cfg
+++ b/packages/models/inky/md5.cfg
@@ -15,3 +15,4 @@ mdlglow 200
 mdlspec 30
 mdltrans 0.5 0 0
 mdlscale 1900
+mdlyaw 90

--- a/packages/models/inky/red/md5.cfg
+++ b/packages/models/inky/red/md5.cfg
@@ -16,4 +16,4 @@ mdlglow 200
 mdlspec 30
 mdltrans 0.5 0 0
 mdlscale 1900
-
+mdlyaw 90

--- a/packages/models/mrfixit/blue/md5.cfg
+++ b/packages/models/mrfixit/blue/md5.cfg
@@ -11,3 +11,4 @@ md5envmap Body socksky/desert
 exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
+mdlyaw 90

--- a/packages/models/mrfixit/md5.cfg
+++ b/packages/models/mrfixit/md5.cfg
@@ -10,3 +10,4 @@ md5envmap Body socksky/desert
 exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
+mdlyaw 90

--- a/packages/models/mrfixit/red/md5.cfg
+++ b/packages/models/mrfixit/red/md5.cfg
@@ -11,3 +11,4 @@ md5envmap Body socksky/desert
 exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
+mdlyaw 90

--- a/packages/models/ogro2/blue/iqm.cfg
+++ b/packages/models/ogro2/blue/iqm.cfg
@@ -18,4 +18,4 @@ mdlglare 1 0
 mdltrans 0 0 1.43
 mdlscale 1800
 mdlextendbb 0 6 1
-
+mdlyaw 90

--- a/packages/models/ogro2/iqm.cfg
+++ b/packages/models/ogro2/iqm.cfg
@@ -16,4 +16,4 @@ mdlglare 1 0
 mdltrans 0 0 1.43
 mdlscale 1800
 mdlextendbb 0 6 1
-
+mdlyaw 90

--- a/packages/models/ogro2/red/iqm.cfg
+++ b/packages/models/ogro2/red/iqm.cfg
@@ -18,4 +18,4 @@ mdlglare 1 0
 mdltrans 0 0 1.43
 mdlscale 1800
 mdlextendbb 0 6 1
-
+mdlyaw 90

--- a/packages/models/snoutx10k/blue/md5.cfg
+++ b/packages/models/snoutx10k/blue/md5.cfg
@@ -16,4 +16,4 @@ exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
 mdlenvmap 0 0 skyboxes/morning
-
+mdlyaw 90

--- a/packages/models/snoutx10k/md5.cfg
+++ b/packages/models/snoutx10k/md5.cfg
@@ -14,4 +14,5 @@ exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
 mdlenvmap 0 0 skyboxes/morning
+mdlyaw 90
 

--- a/packages/models/snoutx10k/red/md5.cfg
+++ b/packages/models/snoutx10k/red/md5.cfg
@@ -16,4 +16,4 @@ exec "packages/models/mrfixit/anims.cfg"
 mdlscale 800
 mdlspec 175
 mdlenvmap 0 0 skyboxes/morning
-
+mdlyaw 90

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -1138,7 +1138,7 @@ VAR(testpitch, -90, 0, 90);
 void renderclient(dynent *d, const char *mdlname, modelattach *attachments, int hold, int attack, int attackdelay, int lastaction, int lastpain, float fade, bool ragdoll, bool onlyshadow)
 {
     int anim = hold ? hold : ANIM_IDLE|ANIM_LOOP;
-    float yaw = testanims && d==player ? 0 : d->yaw+90,
+    float yaw = testanims && d==player ? 0 : d->yaw,
           pitch = testpitch && d==player ? testpitch : d->pitch;
     vec o = d->feetpos();
     int basetime = 0;
@@ -1188,7 +1188,7 @@ void renderclient(dynent *d, const char *mdlname, modelattach *attachments, int 
     else flags |= MDL_CULL_DIST;
     if(d->state==CS_LAGGED) fade = min(fade, 0.3f);
     if(drawtex == DRAWTEX_MODELPREVIEW) flags &= ~(MDL_FULLBRIGHT | MDL_CULL_VFC | MDL_CULL_OCCLUDED | MDL_CULL_QUERY | MDL_CULL_DIST);
-    rendermodel(mdlname, anim, o, yaw, 0, onlyshadow ? pitch/3.f : pitch, onlyshadow && !thirdperson ? MDL_ONLYSHADOW : flags, d, attachments, basetime, 0, fade);
+    rendermodel(mdlname, anim, o, yaw, pitch, 0, onlyshadow && !thirdperson ? MDL_ONLYSHADOW : flags, d, attachments, basetime, 0, fade);
 }
 
 void setbbfrommodel(dynent *d, const char *mdl)


### PR DESCRIPTION
Incrementing the yaw in renderclient() seems to break the pitch animation when looking up and down, this restores it to the tesseract version and adjusts the yaw with `mdlyaw` in the model configuration.