### PR TITLE
Add scoreboard with support for multiple teams

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -72,7 +72,7 @@ bind "PAGEDOWN" [conskip -1000]
 
 bind "BACKQUOTE" [saycommand /]
 bind "SLASH"     [saycommand /]
-bind "TAB"       [holdui scoreboard]
+bind "TAB"       [holdui scoreboard_multiteam]
 bind "SPACE"     [jump]
 bind "RETURN"    [saycommand]
 

--- a/config/game.cfg
+++ b/config/game.cfg
@@ -24,11 +24,11 @@ mapcomplete = [complete $arg1 packages/map ogz]
 mapcomplete map
 mapcomplete coop
 
-modenames = "edit rdm pdm rtdm ptdm rctf pctf"
-
+modenames = "ffa coop teamplay insta instateam effic efficteam tac tacteam capture regencapture ctf instactf protect instaprotect hold instahold efficctf efficprotect effichold collect instacollect efficcollect"
 loop i (listlen $modenames) [
+    local mmname
     mname = (at $modenames $i)
-    alias $mname [if (mode @i) [if (> $numargs 0) [map $arg1] [map]]]
+    alias $mname [ if (mode @i) [if (> $numargs 0) [map $arg1] [map]] ]
     mapcomplete $mname
 ]
 

--- a/config/stdedit.cfg
+++ b/config/stdedit.cfg
@@ -176,8 +176,6 @@ editmovedrag   = [editmovewith editdrag]
 //  Miscellaneous Editing Commands                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-coop = [mode 1; map (? $numargs $arg1 "")]
-
 editfacewsel = [
     if (|| havesel [! (enthavesel)]) [
         if $moving [pushsel $arg1] [

--- a/config/ui.cfg
+++ b/config/ui.cfg
@@ -4,6 +4,7 @@
 exec "config/ui/lib.cfg"			// UI library
 exec "config/ui/style.cfg"			// Styles
 exec "config/ui/scoreboard.cfg"		// Scoreboard
+exec "config/ui/scoreboard_multiteam.cfg" // Sauerract Scoreboard
 exec "config/ui/edithud.cfg"		// Edit HUD
 exec "config/ui/fkey.cfg"			// F#-Key Menus
 exec "config/ui/serverbrowser.cfg"	// Server Browser
@@ -489,7 +490,7 @@ UImenu "notepad" [
             uispace 0.01 0 [UIbar 0 1]
             UIbutton "hold2" [uitext "Clear All"  0.6] 0.04 0.032 [textfocus $UI_notepadfile ; textclear]
         ]
-        uitexteditor $UI_notepadfile -80 20 1 "" 0 [
+        uitexteditor $UI_notepadfile -120 30 0.6 "" 0 [
             uioutline (uifocus? 0xFF0000 $c_line)
             uiclamp- 1 1 1 1
         ]

--- a/config/ui/fkey.cfg
+++ b/config/ui/fkey.cfg
@@ -472,7 +472,7 @@ UImenu "texture_browser" [
                 1 "Utilized" [] // Used Utilized
                 2 "Replace"  []
             ] 1
-            uialign- 0 -1
+            uialign- 1 -1
             UIbutton "hold2" [
                 UIcheckbox $allfaces 0.016
                 uitext "Allfaces" 0.6
@@ -489,7 +489,7 @@ UImenu "texture_browser" [
                         loop slot (numslots) [
                             uislotview $slot 0.145 0.145 [
                                 uihold [uioutline 0xC0C0C0; uiclamp- 1 1 1 1] [uihover [uioutline 0xFFFFFF; uiclamp- 1 1 1 1]]
-                                uirelease [hideui "texture_browser"; settex (getslottex $slot)]
+                                uirelease [settex (getslottex $slot)]
                             ]
                         ]
                     ]
@@ -505,7 +505,7 @@ UImenu "texture_browser" [
                         looptexmru tex [
                             uivslotview $tex 0.145 0.145 [
                                 uihold [uioutline 0xC0C0C0; uiclamp- 1 1 1 1] [uihover [uioutline 0xFFFFFF; uiclamp- 1 1 1 1]]
-                                uirelease [hideui "texture_browser"; settex $tex]
+                                uirelease [settex $tex]
                             ]
                         ]
                     ]

--- a/config/ui/scoreboard_multiteam.cfg
+++ b/config/ui/scoreboard_multiteam.cfg
@@ -1,0 +1,143 @@
+newui "scoreboard_multiteam" [
+    if $mainmenu [hideui "scoreboard_multiteam"]
+    uiallowinput 0
+    UI_scoreboard_isteammode = (m_teammode (getmode))
+    UI_scoreboard_isctfmode = (m_ctf (getmode))
+    UI_scoreboard_getteams = [
+        ? (UI_scoreboard_isteammode) (getteams) "good"
+    ]
+    UI_scoreboard_getteamplayers = [
+        ? (UI_scoreboard_isteammode) (getteamplayers $arg1) (listclients 1)
+    ]
+    UI_scoreboard_getteamscore = [
+        ? (UI_scoreboard_isteammode) (getteamscore $arg1) "Players"
+    ]
+    refreshscoreboard
+    uicolor (? $sbtransparent $c_menu_a $c_menu) 0 0 [
+        uivlist 0 [
+            UI_sbheader
+            uifill 0 0.005
+            UI_multiteamscoreboard
+            uispace 0 0.01
+        ]
+    ]
+] [if $mainmenu [hideui "scoreboard_multiteam"]]
+
+UI_multiteamscoreboard = [
+    local get_player_stats get_player_context_color get_player_icon ispartner isclient header_width_mult
+    header_width_mult = (*f (+f (! $hidefrags) $showping $showscore) 0.1)
+
+    isclient = [= (getclientnum) $arg1]
+    ispartner = [=s (getclientteam (getclientnum)) (getclientteam $arg1)]
+    get_player_context_color = [
+        ? (isauth $arg1) "^f5" (? (isadmin $arg1) "^f2" (? (ismaster $arg1) "^f0" (? (isclient $arg1) "^f8" (? (&& (m_teammode (getmode)) (ispartner $arg1)) "^f1" (? (m_teammode (getmode)) "^f3" "^f7")))))
+    ]
+
+    get_player_stats = [
+        local player
+        player = $arg1
+        if (! $hidefrags) [ uitext (format "%3%1^f4/%4%2" (getclientfrags $player) (getclientdeaths $player) (? (isclient $player) "^f0" "^f4") (? (isclient $player) "^f3" "")) 0.4 ]
+        if (&& $showscore (UI_scoreboard_isteammode)) [ uitext (format "^f9%1" (getclientflags $player)) 0.4 ]
+        if $showping [ uitext (format "^f4%1" (scoreboardping $player)) 0.4 ]
+    ]
+
+    get_player_icon = [
+        local model_index
+        model_index = (? (isclient $arg1) $playermodel (getclientmodel $arg1))
+        format "%1%2" (at ["mrfixit" "snoutx10k" "ogro" "inky" "captaincannon"] $model_index) (? (UI_scoreboard_isteammode) (? (ispartner $arg1) "_blue" "_red") "")
+    ]
+
+    uifill 0 0.15 [
+        uivlist 0.005 [
+            local grid_columns
+            grid_columns = (max (div (listlen (UI_scoreboard_getteams)) (+ (>= (listlen (UI_scoreboard_getteams)) 3) 2)) 2)
+
+            uigrid $grid_columns 0.006125 0.006125 [
+                loop t (listlen (UI_scoreboard_getteams)) [
+                    local team_name team_players
+                    team_name = (at (UI_scoreboard_getteams) $t)
+                    team_players = (listfilter cn (UI_scoreboard_getteamplayers $t) [! (isspectator $cn)])
+                    if (listlen $team_players) [
+                        uivlist 0 [
+                            uifill $header_width_mult
+                            uicolor (? (UI_scoreboard_isteammode) (? (=s (getclientteam (getclientnum)) $team_name) 0x4060D0 0xD04040) 0x40A040) (maxf $header_width_mult 0.2) 0 [
+                                uitext (format "^f7%1" (UI_scoreboard_getteamscore $t)) 0.8
+                                uiclamp 1 1 1 1
+                            ]
+
+                            uitable 0.04 0 [
+                                uitableheader [
+                                    uitext "^f4Name" 0.45
+                                    if (! $hidefrags) [ uitext "^f4Frags/Deaths" 0.45 ]
+                                    if (&& $showscore (UI_scoreboard_isteammode)) [ uitext "^f4Scores" 0.45 ]
+                                    if $showping [ uitext "^f4Ping" 0.45 ]
+                                ]
+                                looplist player $team_players [
+                                    uitablerow [
+                                        uitextfill 9 0 [
+                                            uihlist 0.001 [
+                                                UIicon (get_player_icon $player) 0.02
+                                                uialign -1
+                                                uitext (format "%2%1" (getclientname $player) (get_player_context_color $player)) 0.4
+                                                uitext (format "^f4(%1)" $player) 0.35
+                                            ]
+                                        ]
+
+                                        get_player_stats $player
+                                    ] [
+                                        uicolor (? (isclient $player) 0x223355 (? (&& (UI_scoreboard_isteammode) (ispartner $player)) 0x111122 (? (UI_scoreboard_isteammode) 0x221111 0x111111))) (+f $header_width_mult 0.2) 0 [
+                                            uioutline (? (isclient $player) 0xFFFFFF 0x222222) 0 0.02 [ 
+                                                uiclamp 1 1 1 1
+                                            ]
+                                        ]
+                                        if (isclient $player) [uispace 0 0.011]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+                if (listlen (listfilter cn (listclients 1) [isspectator $cn])) [
+                    uivlist 0.005 [
+                        uicolor 0xbbbbbb $header_width_mult 0 [
+                            uitext "Spectators" 0.8
+                            uiclamp 1 1 1 1
+                        ]
+                        uitable 0.04 0 [
+                            uitableheader [
+                                uitext "^f4Name" 0.45
+                                if (! $hidefrags) [ uitext "^f4Frags/Deaths" 0.45 ]
+                                if (&& $showscore (UI_scoreboard_isteammode)) [ uitext "^f4Scores" 0.45 ]
+                                if $showping [ uitext "^f4Ping" 0.45 ]
+                            ]
+                            looplist player (listclients 1) [
+                                if (isspectator $player) [
+                                    uitablerow [
+                                        uitextfill 9 0 [
+                                            uihlist 0.001 [
+                                                UIicon (get_player_icon $player) 0.02
+                                                uialign -1
+                                                uitext (format "%2%1" (getclientname $player) (get_player_context_color $player)) 0.4
+                                                uitext (format "^f4(%1)" $player) 0.35
+                                            ]
+                                        ]
+                                        get_player_stats $player
+                                    ] [
+                                        uicolor (? (isclient $player) 0x223355 0x222222) (+f $header_width_mult 0.2) 0 [
+                                            uioutline 0x333333 0 0.02 [ 
+                                                uiclamp 1 1 1 1
+                                            ]
+
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+
+
+        ]
+    ]
+]

--- a/src/game/scoreboard.cpp
+++ b/src/game/scoreboard.cpp
@@ -334,12 +334,12 @@ namespace game
         if(d) result(colorname(d));
     });
 
-    int getclientteam(int cn)
+    const char *getclientteam(int cn)
     {
         fpsent *d = getclient(cn);
-        return m_teammode && d ? !strcmp(d->team, "evil") ? 2 : 1 : 0;
+        return d ? d->team : "";
     }
-    ICOMMAND(getclientteam, "i", (int *cn), intret(getclientteam(*cn)));
+    ICOMMAND(getclientteam, "i", (int *cn), result(getclientteam(*cn)));
 
     int getclientmodel(int cn)
     {
@@ -392,6 +392,40 @@ namespace game
         {
             scoregroup &sg = *groups[*team];
             result(sg.team);
+        }
+    });
+
+    ICOMMAND(getteams, "", (),
+    {
+        if (m_teammode)
+        {
+            vector<char> s;
+            loopi(groupplayers())
+            {
+                scoregroup &sg = *groups[i];
+                if (i > 0) s.add(' ');
+                s.put(sg.team, strlen(sg.team));
+            }
+            s.add('\0');
+            result(s.getbuf());
+        }
+    });
+
+    ICOMMAND(getteamplayers, "i", (int *team),
+    {
+        if (m_teammode && *team <= groupplayers() - 1)
+        {
+            vector<char> s;
+            scoregroup &sg = *groups[*team];
+            loopvj(sg.players)
+            {
+                if (j > 0) s.add(' ');
+                fpsent *p = sg.players[j];
+                defformatstring(clientnum, "%d", p->clientnum);
+                s.put(clientnum, strlen(clientnum));
+            }
+            s.add('\0');
+            result(s.getbuf());
         }
     });
 


### PR DESCRIPTION
This is an attempt to support multiple teams on the scoreboard like in Sauer (https://github.com/Big-Onche/Tesseract-Sauerbraten/issues/9).

![2024-05-19_10 50 37_venice_insta-team](https://github.com/Big-Onche/Tesseract-Sauerbraten/assets/9287152/5d753882-3d54-4d53-85a2-d408b5147cb6)
![2024-05-19_11 20 17_complex_insta-team](https://github.com/Big-Onche/Tesseract-Sauerbraten/assets/9287152/208b2afa-cdff-4317-bf13-84e6f4a2087d)
![2024-05-19_10 55 12_coop-edit](https://github.com/Big-Onche/Tesseract-Sauerbraten/assets/9287152/c24cdc84-9bb3-4e17-af32-c9f5856b7822)

The changes adjust the value that the `getclientteam` command returns and add `getteams` and `getteamplayers`.
(it also replaces the default.cfg bind for the tab key, which probably requires a restore of the configs to take effect)

Frags, Score and Ping can be disabled/enabled with `hidefrags`, `showscore` and `showping`.
I'm still not 100% confident that something isn't broken, so feel free to point it out if you find any issue!

