### PR TITLE
Fix monsters yaw and restore .md2 animations

### DIFF
--- a/config/game.cfg
+++ b/config/game.cfg
@@ -66,6 +66,14 @@ loop i (listlen $modenames) [
     mapcomplete $mname
 ]
 
+spmodenames = "sp dmsp"
+loop i (listlen $spmodenames) [
+    local mname
+    mname = (at $spmodenames $i)
+    alias $mname [ if (mode (- @i 3)) [if (> $numargs 0) [map $arg1] [map]] ]
+    mapcomplete $mname
+]
+
 demo = [stopdemo; if (mode -1) [map $arg1]]
 varcomplete demo demodir dmo
 

--- a/packages/models/monster/bauul/md2.cfg
+++ b/packages/models/monster/bauul/md2.cfg
@@ -2,3 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 240
 mdltrans 0 0 24
+mdlyaw 90

--- a/packages/models/monster/goblin/md2.cfg
+++ b/packages/models/monster/goblin/md2.cfg
@@ -2,3 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 130
 mdltrans 0 0 24
+mdlyaw 90

--- a/packages/models/monster/hellpig/md2.cfg
+++ b/packages/models/monster/hellpig/md2.cfg
@@ -10,5 +10,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 120
 mdltrans 0 0 24
-
-
+mdlyaw 90

--- a/packages/models/monster/knight/md2.cfg
+++ b/packages/models/monster/knight/md2.cfg
@@ -2,5 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 180
 mdltrans 0 0 24
-
-
+mdlyaw 90

--- a/packages/models/monster/md2.cfg
+++ b/packages/models/monster/md2.cfg
@@ -1,3 +1,4 @@
 md2pitch .25
 mdlspec 50
 mdltrans 0 0 24
+mdlyaw 90

--- a/packages/models/monster/rat/md2.cfg
+++ b/packages/models/monster/rat/md2.cfg
@@ -2,3 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 140
 mdltrans 0 0 24
+mdlyaw 90

--- a/packages/models/monster/rhino/md2.cfg
+++ b/packages/models/monster/rhino/md2.cfg
@@ -2,3 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 80
 mdltrans 0 0 24
+mdlyaw 90

--- a/packages/models/monster/slith/md2.cfg
+++ b/packages/models/monster/slith/md2.cfg
@@ -2,4 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 180
 mdltrans 0 0 24
-
+mdlyaw 90

--- a/packages/models/monster/spider/md3.cfg
+++ b/packages/models/monster/spider/md3.cfg
@@ -13,3 +13,4 @@ md3anim dying 120 17 50
 md3anim dead 137 1
 
 mdlscale 2000
+mdlyaw 90

--- a/packages/models/ogro/md2.cfg
+++ b/packages/models/ogro/md2.cfg
@@ -2,3 +2,4 @@ md2pitch .25
 mdlspec 50
 mdlscale 100
 mdltrans 0 0 24
+mdlyaw 90

--- a/src/engine/md2.h
+++ b/src/engine/md2.h
@@ -206,6 +206,55 @@ struct md2 : vertloader<md2>
         }
     };
 
+    struct md2part : part
+    {
+        md2part(animmodel* model, int index = 0) : part(model, index)
+        {
+        }
+
+        void getdefaultanim(animinfo& info, int anim, uint varseed, dynent* d)
+        {
+            //                      0              3              6   7   8   9   10   11  12  13   14  15  16  17
+            //                      D    D    D    D    D    D    A   P   I   R,  E    J   T   W    FO  SA  GS  GI
+            static const int _frame[] = { 178, 184, 190, 183, 189, 197, 46, 54, 0,  40, 162, 67, 95, 112, 72, 84, 7,  6 };
+            static const int _range[] = { 6,   6,   8,   1,   1,   1,   8,  4,  40, 6,  1,   1,  17, 11,  12, 11, 18, 1 };
+            //                      DE DY I  F  B  L  R  H1 H2 H3 H4 H5 H6 H7 A1 A2 A3 A4 A5 A6 A7 PA J   SI SW ED  LA  T   WI  LO  GI  GS
+            static const int animfr[] = { 5, 2, 8, 9, 9, 9, 9, 8, 8, 8, 8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 7, 11, 8, 9, 10, 14, 12, 13, 15, 17, 16 };
+
+            anim &= ANIM_INDEX;
+            if ((size_t)anim >= sizeof(animfr) / sizeof(animfr[0]))
+            {
+                info.frame = 0;
+                info.range = 1;
+                return;
+            }
+            int n = animfr[anim];
+            switch (anim)
+            {
+            case ANIM_DYING:
+            case ANIM_DEAD:
+                n -= varseed % 3;
+                break;
+            case ANIM_FORWARD:
+            case ANIM_BACKWARD:
+            case ANIM_LEFT:
+            case ANIM_RIGHT:
+            case ANIM_SWIM:
+                info.speed = 5500.0f / d->maxspeed;
+                break;
+            }
+            info.frame = _frame[n];
+            info.range = _range[n];
+        }
+    };
+
+    md2part& addpart()
+    {
+        md2part* p = new md2part(this, parts.length());
+        parts.add(p);
+        return *p;
+    }
+
     vertmeshgroup *newmeshes() { return new md2meshgroup; }
 
     bool loadconfig() { return false; }


### PR DESCRIPTION
this adds `mdlyaw 90` to the monsters .cfg (#39) and restores a missing part of engine/md2.h that prevented animations from working correctly for .md2 models (#11).

(/sp and /dmsp should work properly now too)