### PR TITLE
Fix client rendering while in dead or spectator state

### DIFF
--- a/config/game.cfg
+++ b/config/game.cfg
@@ -34,13 +34,7 @@ crosshairs = [
     "dot_whole.png"     "dot_whole_hit.png"
 ]
 
-nextspecmode = [
-    if $specmode [
-        specmode (mod (+ $specmode 1) 3)
-    ] [
-        specmode (? (>= (getfollow) 0) 2 1)
-    ]
-]
+nextspecmode = [ follow ]
 
 defvarp zooming 0 0 1
 

--- a/config/ui.cfg
+++ b/config/ui.cfg
@@ -74,7 +74,7 @@ UImenu "main" [
                     1] [UI_MainMenuButton "Switch Team: ^f3Evil" "action" [team "evil"]] [
                     2] [UI_MainMenuButton "Switch Team: ^f1Good" "action" [team "good"]]
                 uifill 0.2 0.02 [UIbar 1]
-                UI_MainMenuButton (concatword (? $isspectator "^f1Leave" "^f7Toggle") " Spectator") "spectator" [spectator (! (isspectator (getclientnum)))]
+                UI_MainMenuButton (concatword (? (isspectator (getclientnum)) "^f1Leave" "^f7Toggle") " Spectator") "spectator" [spectator (! (isspectator (getclientnum))); hideallui]
                 UI_MainMenuButton "Master" "arrow_fw" [menu_master]
                 if (ismaster $getclientnum) [
                     UI_MainMenuButton "Bots" "arrow_fw" [hideui "main" ; showui "bots"]

--- a/src/game/render.cpp
+++ b/src/game/render.cpp
@@ -190,7 +190,7 @@ namespace game
             case 2: mdlname = mdl.redteam; break;
         }
 
-        if(d->state==CS_ALIVE || d->state==CS_LAGGED) renderclient(d, mdlname, a[0].tag ? a : NULL, hold, attack, delay, lastaction, intermission && d->state!=CS_DEAD ? 0 : d->lastpain, fade, ragdoll && mdl.ragdoll, onlyshadow);
+        renderclient(d, mdlname, a[0].tag ? a : NULL, hold, attack, delay, lastaction, intermission && d->state!=CS_DEAD ? 0 : d->lastpain, fade, ragdoll && mdl.ragdoll, onlyshadow);
 #if 0
         if(d->state!=CS_DEAD && d->quadmillis)
         {
@@ -348,7 +348,7 @@ namespace game
                 fade -= clamp(float(lastmillis - (d->lastupdate + max(ragdollmillis - ragdollfade, 0)))/min(ragdollmillis, ragdollfade), 0.0f, 1.0f);
             renderplayer(d, getplayermodelinfo(d), team, fade, mainpass);
         }
-        if(player1->state!=CS_DEAD || hidedead != 1) renderplayer(player1, getplayermodelinfo(player1), teamskins || m_teammode ? 1 : 0, 1, mainpass);
+        if(isthirdperson() && !followingplayer() && (player1->state != CS_DEAD || hidedead != 1)) renderplayer(player1, getplayermodelinfo(player1), teamskins || m_teammode ? 1 : 0, 1, mainpass);
         rendermonsters();
         rendermovables();
         entities::renderentities();


### PR DESCRIPTION
checks `isthirdperson() && !followingplayer()` before running `renderplayer()`, allowing `renderclient()` to run even if not in live or lagged state, but never while watching other players in first person (fixes #31).