### PR TITLE
Attempt to make `/savemap` compatible with Sauer & fix mapmodel attribute ordering

### DIFF
--- a/config/stdedit.cfg
+++ b/config/stdedit.cfg
@@ -7,7 +7,7 @@ Path_NoTexture = "game/notexture.png"
 ent_action_base           = [ entproperty 0 ( * $arg1 1 ) ]
 ent_action_teleport       = [ entproperty 0 ( * $arg1 1 ) ]
 ent_action_teledest       = [ entproperty 1 ( * $arg1 1 ) ]
-ent_action_mapmodel       = [ entproperty 0 ( * $arg1 1 ) ]
+ent_action_mapmodel       = [ entproperty 1 ( * $arg1 1 ) ]
 ent_action_spotlight      = [ entproperty 0 ( * $arg1 5 ) ]
 ent_action_light          = [ entproperty 0 ( * $arg1 5 ) ]
 ent_action_jumppad        = [ entproperty 0 ( * $arg1 5 ) ]
@@ -188,7 +188,7 @@ editfacewsel = [
 ]
 
 entswithdirection = [playerstart teledest mapmodel decal flag]
-entdirectionprop  = [0           0        1        1    ]
+entdirectionprop  = [0           0        0        1    ]
 
 entdirection = [
     if (&& (enthavesel) [= (havesel) 0]) [

--- a/config/ui/fkey.cfg
+++ b/config/ui/fkey.cfg
@@ -41,11 +41,11 @@ UI_entedt_markup = [
     ]
     // light: radius|color1|color2|color3
     [ 0 4 5 6 [button "^"Append Spotlight^"" [[sleep 0 [entdrop @entdrop]; entdrop 0; newent spotlight]]] ]
-    // mapmodel: model|yaw|pitch|roll
+    // mapmodel: yaw|model|pitch|roll
     [
-        12 16 17 18
-        [text (mapmodelname (entattr 0) 1) 0.3 0]
-        [button "^"Reload Model^"" [[clearmodel (mapmodelname (entattr 0) 1); resetgl]]]
+        16 12 17 18
+        [text (mapmodelname (entattr 1) 1) 0.3 0]
+        [button "^"Reload Model^"" [[clearmodel (mapmodelname (entattr 1) 1); resetgl]]]
     ]
     // playerstart: direction|team
     [ 1 [listslider "Team" ["^f4Neutral ^f1Good ^f3Evil"] ["0 1 2"]] ]
@@ -552,12 +552,12 @@ newui "mapmodel" [
                                             uiclamp* 1 1 1 1
                                             UI_selmdl = $i
                                             uirelease [
-                                                newent mapmodel $i
+                                                newent mapmodel 0 $i
                                                 _io_mapmodel = 0
                                             ]
                                             uiescrelease [
                                                 if (enthavesel) [
-                                                    entset "mapmodel" $i
+                                                    entset "mapmodel" 0 $i
                                                     _io_mapmodel = 0
                                                 ]
                                             ]

--- a/config/ui/gui_to_ui.cfg
+++ b/config/ui/gui_to_ui.cfg
@@ -21,19 +21,26 @@ newgui = [
     ]
 ]
 
+// UI already stays open
+guistayopen = [
+    arg1
+]
+
 showgui = [
     showui [gui_@arg1]
+
 ]
 
 cleargui = [
-    togglemainmenu
+    //togglemainmenu
+    mainmenutoggled
 ]
 
 guitext = [
     uispace 0 0.003 [
         uialign -1 2
         uihlist 0 [
-            if (|| (=s @@arg2 "") @@arg2) [
+            if (|| (=s @@arg2 "") (=s @@arg2 "1")) [
                 uiimage "packages/interface/icons/info.jpg" 0.04 0.04
             ] [
                 uispace 0 0.02 // small vertical spacer if no icon
@@ -45,12 +52,17 @@ guitext = [
 ]
 
 guibutton = [
+    local button_icon
     uispace -0.008 0 [
         uialign -1 -2
         UIbutton "" [
             uihlist 0 [
-                if (|| (=s @@arg3 "") @@arg3) [
+                if (|| (=s @@arg3 "") (=s @@arg3 "1")) [
                     uiimage "packages/interface/icons/menu.jpg" 0.04 0.04
+                ] [
+                    if (!=s @@arg3 "0") [
+                        uiimage (format "packages/interface/icons/%1.jpg" @@arg3) 0.04 0.04
+                    ]
                 ]
                 
                 uitext [@@arg1] 0.8

--- a/src/engine/bih.cpp
+++ b/src/engine/bih.cpp
@@ -310,7 +310,7 @@ BIH::~BIH()
 
 bool mmintersect(const extentity &e, const vec &o, const vec &ray, float maxdist, int mode, float &dist)
 {
-    model *m = loadmapmodel(e.attr1);
+    model *m = loadmapmodel(e.attr2);
     if(!m) return false;
     if((mode&RAY_ENTS)!=RAY_ENTS && (!m->collide || e.flags&EF_NOCOLLIDE)) return false;
     if(!m->bih && !m->setBIH()) return false;
@@ -318,7 +318,7 @@ bool mmintersect(const extentity &e, const vec &o, const vec &ray, float maxdist
     vec mo = vec(o).sub(e.o).mul(scale), mray(ray);
     float v = mo.dot(mray), inside = m->bih->entradius - mo.squaredlen();
     if((inside < 0 && v > 0) || inside + v*v < 0) return false;
-    int yaw = e.attr2, pitch = e.attr3, roll = e.attr4;
+    int yaw = e.attr1, pitch = e.attr3, roll = e.attr4;
     if(yaw != 0)
     {
         const vec2 &rot = sincosmod360(-yaw);

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -738,12 +738,12 @@ bool mmcollide(physent *d, const vec &dir, float cutoff, octaentities &oc) // co
     loopv(oc.mapmodels)
     {
         extentity &e = *ents[oc.mapmodels[i]];
-        if(e.flags&EF_NOCOLLIDE || !mapmodels.inrange(e.attr1)) continue;
-        mapmodelinfo &mmi = mapmodels[e.attr1];
+        if(e.flags&EF_NOCOLLIDE || !mapmodels.inrange(e.attr2)) continue;
+        mapmodelinfo &mmi = mapmodels[e.attr2];
         model *m = mmi.collide;
         if(!m)
         {
-            if(!mmi.m && !loadmodel(NULL, e.attr1)) continue;
+            if(!mmi.m && !loadmodel(NULL, e.attr2)) continue;
             if(mmi.m->collidemodel) m = loadmodel(mmi.m->collidemodel);
             if(!m) m = mmi.m;
             mmi.collide = m;
@@ -755,7 +755,7 @@ bool mmcollide(physent *d, const vec &dir, float cutoff, octaentities &oc) // co
         float rejectradius = m->collisionbox(center, radius), scale = e.attr5 > 0 ? e.attr5/100.0f : 1;
         if(d->o.reject(e.o, d->radius + rejectradius*scale)) continue;
 
-        int yaw = e.attr2, pitch = e.attr3, roll = e.attr4;
+        int yaw = e.attr1, pitch = e.attr3, roll = e.attr4;
         if(mcol == COLLIDE_TRI || testtricol)
         {
             if(!m->bih && !m->setBIH()) continue;

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -392,7 +392,7 @@ void preloadusedmapmodels(bool msg, bool bih)
     loopv(ents)
     {
         extentity &e = *ents[i];
-        if(e.type==ET_MAPMODEL && e.attr1 >= 0 && used.find(e.attr1) < 0) used.add(e.attr1);
+        if(e.type==ET_MAPMODEL && e.attr2 >= 0 && used.find(e.attr2) < 0) used.add(e.attr2);
     }
 
     vector<const char *> col;

--- a/src/engine/renderva.cpp
+++ b/src/engine/renderva.cpp
@@ -510,7 +510,7 @@ static inline void rendermapmodel(extentity &e)
     int anim = ANIM_MAPMODEL|ANIM_LOOP, basetime = 0;
     if(e.flags&EF_ANIM) entities::animatemapmodel(e, anim, basetime);
     //rendermapmodel(e.attr1, anim, e.o, e.attr2, e.attr3, e.attr4, MDL_CULL_VFC | MDL_CULL_DIST, basetime, e.attr5 > 0 ? e.attr5/100.0f : 1.0f);
-    rendermapmodel(e.attr1, anim, e.o, e.attr2, 0, 0, MDL_CULL_VFC | MDL_CULL_DIST, basetime, 1.0f);
+    rendermapmodel(e.attr2, anim, e.o, e.attr1, 0, 0, MDL_CULL_VFC | MDL_CULL_DIST, basetime, 1.0f);
 }
 
 void rendermapmodels()
@@ -2692,12 +2692,12 @@ static void genshadowmeshmapmodels(shadowmesh &m, int sides, shadowdrawinfo draw
         e.flags &= ~EF_RENDER;
 
 
-        model *mm = loadmapmodel(e.attr1);
+        model *mm = loadmapmodel(e.attr2);
         if(!mm || !mm->shadow || mm->animated() || (mm->alphashadow && mm->alphatested())) continue;
 
         matrix4x3 orient;
         orient.identity();
-        if(e.attr2) orient.rotate_around_z(sincosmod360(e.attr2));
+        if(e.attr1) orient.rotate_around_z(sincosmod360(e.attr1));
         if(e.attr3) orient.rotate_around_x(sincosmod360(e.attr3));
         if(e.attr4) orient.rotate_around_y(sincosmod360(-e.attr4));
         if(e.attr5 > 0) orient.scale(e.attr5/100.0f);

--- a/src/engine/stain.cpp
+++ b/src/engine/stain.cpp
@@ -689,7 +689,7 @@ struct stainrenderer
         loopv(oe.mapmodels)
         {
             extentity &e = *ents[oe.mapmodels[i]];
-            model *m = loadmapmodel(e.attr1);
+            model *m = loadmapmodel(e.attr2);
             if(!m) continue;
 
             vec center, radius;
@@ -699,7 +699,7 @@ struct stainrenderer
 
             if(m->animated() || (!m->bih && !m->setBIH())) continue;
 
-            int yaw = e.attr2, pitch = e.attr3, roll = e.attr4;
+            int yaw = e.attr1, pitch = e.attr3, roll = e.attr4;
 
             m->bih->genstaintris(this, staincenter, stainradius, e.o, yaw, pitch, roll, scale);
         }

--- a/src/engine/world.cpp
+++ b/src/engine/world.cpp
@@ -14,7 +14,7 @@ VAR(entselradius, 0, 2, 10);
 static inline void transformbb(const entity &e, vec &center, vec &radius)
 {
     if(e.attr5 > 0) { float scale = e.attr5/100.0f; center.mul(scale); radius.mul(scale); }
-    rotatebb(center, radius, e.attr2, e.attr3, e.attr4);
+    rotatebb(center, radius, e.attr1, e.attr3, e.attr4);
 }
 
 static inline void mmboundbox(const entity &e, model *m, vec &center, vec &radius)
@@ -55,7 +55,7 @@ bool getentboundingbox(const extentity &e, ivec &o, ivec &r)
                 break;
             }
         case ET_MAPMODEL:
-            if(model *m = loadmapmodel(e.attr1))
+            if(model *m = loadmapmodel(e.attr2))
             {
                 vec center, radius;
                 mmboundbox(e, m, center, radius);
@@ -106,7 +106,7 @@ void modifyoctaentity(int flags, int id, extentity &e, cube *c, const ivec &cor,
                     oe.bbmax.max(br).min(ivec(oe.o).add(oe.size));
                     break;
                 case ET_MAPMODEL:
-                    if(loadmapmodel(e.attr1))
+                    if(loadmapmodel(e.attr2))
                     {
                         if(va)
                         {
@@ -153,7 +153,7 @@ void modifyoctaentity(int flags, int id, extentity &e, cube *c, const ivec &cor,
                     oe.bbmax.min(ivec(oe.o).add(oe.size));
                     break;
                 case ET_MAPMODEL:
-                    if(loadmapmodel(e.attr1))
+                    if(loadmapmodel(e.attr2))
                     {
                         oe.mapmodels.removeobj(id);
                         if(va)
@@ -563,7 +563,7 @@ void entselectionbox(const entity &e, vec &eo, vec &es)
         eo.y += e.o.y;
         eo.z = e.o.z - entselradius + es.z;
     }
-    else if(e.type == ET_MAPMODEL && (m = loadmapmodel(e.attr1)))
+    else if(e.type == ET_MAPMODEL && (m = loadmapmodel(e.attr2)))
     {
         mmcollisionbox(e, m, eo, es);
         es.max(entselradius);
@@ -786,7 +786,7 @@ void renderentradius(extentity &e, bool color)
             if(color) gle::colorf(0, 1, 1);
             entities::entradius(e, color);
             vec dir;
-            vecfromyawpitch(e.attr2, e.attr3, 1, 0, dir);
+            vecfromyawpitch(e.attr1, e.attr3, 1, 0, dir);
             renderentarrow(e, dir, 4);
             break;
         }
@@ -1007,7 +1007,7 @@ bool dropentity(entity &e, int drop = -1)
     if(drop<0) drop = entdrop;
     if(e.type == ET_MAPMODEL)
     {
-        model *m = loadmapmodel(e.attr1);
+        model *m = loadmapmodel(e.attr2);
         if(m)
         {
             vec center;
@@ -1097,7 +1097,7 @@ extentity *newentity(bool local, const vec &o, int type, int v1, int v2, int v3,
                 }
                 break;
             case ET_MAPMODEL:
-                if(!e.attr2) e.attr2 = (int)camera1->yaw;
+                if(!e.attr1) e.attr1 = (int)camera1->yaw;
                 break;
             case ET_PLAYERSTART:
                 e.attr5 = e.attr4;

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -2,6 +2,8 @@
 
 #include "engine.h"
 
+static const char *const tesscompatvar = "__sauerract_mapversion";
+
 void validmapname(char *dst, const char *src, const char *prefix = NULL, const char *alt = "untitled", size_t maxlen = 100)
 {
     if(prefix) while(*prefix) *dst++ = *prefix++;
@@ -54,7 +56,10 @@ static bool loadmapheader(stream *f, const char *ogzname, mapheader &hdr, octahe
     }
     else if(!memcmp(hdr.magic, "OCTA", 4))
     {
-        if(hdr.version!=OCTAVERSION) return false;
+        memcpy(ohdr.magic, hdr.magic, 4);
+        ohdr.version = hdr.version;
+        ohdr.headersize = hdr.headersize;
+        if(ohdr.version!=OCTAVERSION) return false;
         if(f->read(&ohdr.worldsize, 7*sizeof(int)) != 7*sizeof(int)) return false;
         lilswap(&ohdr.worldsize, 7);
         if(ohdr.worldsize <= 0|| ohdr.numents < 0) return false;
@@ -1033,23 +1038,24 @@ bool save_world(const char *mname, bool nolms)
     savemapprogress = 0;
     renderprogress(0, "saving map...");
 
-    mapheader hdr;
-    memcpy(hdr.magic, "TMAP", 4);
-    hdr.version = MAPVERSION;
+    octaheader hdr;
+    memcpy(hdr.magic, "OCTA", 4);
+    hdr.version = OCTAVERSION;
     hdr.headersize = sizeof(hdr);
     hdr.worldsize = worldsize;
     hdr.numents = 0;
     const vector<extentity *> &ents = entities::getents();
     loopv(ents) if(ents[i]->type!=ET_EMPTY || nolms) hdr.numents++;
     hdr.numpvs = nolms ? 0 : getnumviewcells();
+    hdr.lightmaps = 0;
     hdr.blendmap = shouldsaveblendmap();
-    hdr.numvars = 0;
+    hdr.numvars = 1;
     hdr.numvslots = numvslots;
     enumerate(idents, ident, id,
     {
         if((id.type == ID_VAR || id.type == ID_FVAR || id.type == ID_SVAR) && id.flags&IDF_OVERRIDE && !(id.flags&IDF_READONLY) && id.flags&IDF_OVERRIDDEN) hdr.numvars++;
     });
-    lilswap(&hdr.version, 8);
+    lilswap(&hdr.version, 9);
     f->write(&hdr, sizeof(hdr));
 
     enumerate(idents, ident, id,
@@ -1077,6 +1083,11 @@ bool save_world(const char *mname, bool nolms)
                 break;
         }
     });
+
+    f->putchar(ID_VAR);
+    f->putlil<ushort>(strlen(tesscompatvar));
+    f->write(tesscompatvar, strlen(tesscompatvar));
+    f->putlil<int>(MAPVERSION);
 
     if(dbgvars) conoutf(CON_DEBUG, "wrote %d vars", hdr.numvars);
 
@@ -1177,8 +1188,6 @@ bool trynewmap(const char *mname, const char *cname) // sauerract | try to load 
     Texture *mapshot = textureload(picname, 3, true, false);
     renderbackground("loading...", mapshot, mname, game::getmapinfo());
 
-    setvar("mapversion", hdr.version, true, false);
-
     renderprogress(0, "clearing world...");
 
     freeocta(worldroot);
@@ -1190,6 +1199,9 @@ bool trynewmap(const char *mname, const char *cname) // sauerract | try to load 
     setvar("mapscale", worldscale, true, false);
 
     renderprogress(0, "loading vars...");
+
+    bool hastessformat = false;
+    int tessversion = hdr.version;
 
     loopi(hdr.numvars)
     {
@@ -1215,6 +1227,15 @@ bool trynewmap(const char *mname, const char *cname) // sauerract | try to load 
                 break;
             }
             default: continue;
+        }
+        if(!strcmp(name, tesscompatvar))
+        {
+            if(type == ID_VAR)
+            {
+                tessversion = val.getint();
+                hastessformat = true;
+            }
+            continue;
         }
         if(id && id->flags&IDF_OVERRIDE) switch(id->type)
         {
@@ -1245,6 +1266,9 @@ bool trynewmap(const char *mname, const char *cname) // sauerract | try to load 
         }
     }
     if(dbgvars) conoutf(CON_DEBUG, "read %d vars", hdr.numvars);
+
+    if(hastessformat) hdr.version = tessversion;
+    setvar("mapversion", hdr.version, true, false);
 
     string gametype;
     bool samegame = true;

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -97,11 +97,11 @@ static void fixent(entity &e, int version)
         if(version <= 31 && e.type == ET_MAPMODEL) { int yaw = (int(e.attr1)%360 + 360)%360 + 7; e.attr1 = yaw - yaw%15; }
     }
 
-    if(e.type == ET_MAPMODEL && version < 33) // sauerract | invert mdl id and pitch for sauerbraten port
+    /*if(e.type == ET_MAPMODEL && version < 33) // sauerract | invert mdl id and pitch for sauerbraten port
     {
         int attr1 = e.attr1, attr2 = e.attr2;
         e.attr1 = attr2, e.attr2 = attr1;
-    }
+    }*/
 }
 
 bool loadents(const char *fname, vector<entity> &ents, uint *crc)
@@ -1766,19 +1766,19 @@ void writecollideobj(char *name)
         conoutf(CON_ERROR, "could not find map model in selection");
         return;
     }
-    model *m = loadmapmodel(mm->attr1);
+    model *m = loadmapmodel(mm->attr2);
     if(!m)
     {
-        mapmodelinfo *mmi = getmminfo(mm->attr1);
+        mapmodelinfo *mmi = getmminfo(mm->attr2);
         if(mmi) conoutf(CON_ERROR, "could not load map model: %s", mmi->name);
-        else conoutf(CON_ERROR, "could not find map model: %d", mm->attr1);
+        else conoutf(CON_ERROR, "could not find map model: %d", mm->attr2);
         return;
     }
 
     matrix4x3 xform;
     m->calctransform(xform);
     float scale = mm->attr5 > 0 ? mm->attr5/100.0f : 1;
-    int yaw = mm->attr2, pitch = mm->attr3, roll = mm->attr4;
+    int yaw = mm->attr1, pitch = mm->attr3, roll = mm->attr4;
     matrix3 orient;
     orient.identity();
     if(scale != 1) orient.scale(scale);


### PR DESCRIPTION
Tess uses attr1 for the mapmodel index and attr2 for the orientation, and Sauer does the opposite. We already have a quick fix here:

https://github.com/Big-Onche/Tesseract-Sauerbraten/blob/6cbb8b3ff15da65e54e5f5aa884be33cf08e91e8/src/engine/worldio.cpp#L95-L99

while it is sufficient to load Sauer maps, it can cause inconsistencies for scripts, etc., that are made with Sauer in mind.

the solution is somewhat complicated since we have to edit all the places that use attr1 to load the mapmodel (that's why the quick fix is there, right? :P). This is an attempt to do that. It requires testing though. I haven't noticed any issues, but I'm not absolutely sure if I've covered all the occurrences.

it also requires re-executing the configs with `/exec config/ui.cfg` to apply the entity menu changes.

one side effect is that maps made in vanilla Tesseract will have their mapmodels broken (since we are now compatible with Sauer). maybe we could add a condition to fix that as well?

<hr>

This PR also attempts to fix #34 by making maps saved using Sauerract compatible with Sauer. The idea is simply to use the "OCTA" header while embedding a variable (`__sauerract_mapversion`) that Sauerract can read to identify it as its own map (differentiating it from a map actually originating from Sauer). It seems to work, but it also requires more testing :)